### PR TITLE
[Engineer] Project scaffolding: Rust + Ratatui boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Rust build artifacts
+/target/
+Cargo.lock
+
+# IDEs
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tomogotchi-cli"
+version = "0.1.0"
+edition = "2021"
+authors = ["Sedona Agent Fleet <agents@kabletv.com>"]
+description = "A CLI-based tamagotchi app built with Rust and Ratatui"
+
+[dependencies]
+ratatui = "0.29"
+crossterm = "0.28"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Tomogotchi CLI
+
+A CLI-based tamagotchi app built with Rust and Ratatui TUI framework.
+
+## Features (WIP)
+
+- 🎮 Interactive terminal UI
+- 🐾 Virtual pet with mood and stats
+- 🍖 Feed your pet
+- 🎾 Play with your pet
+- 💝 Keep your pet happy and healthy!
+
+## Prerequisites
+
+- Rust 1.70 or later
+- A terminal that supports Unicode and colors
+
+## Installation
+
+```bash
+cargo build --release
+```
+
+## Running
+
+```bash
+cargo run
+```
+
+Or after building:
+
+```bash
+./target/release/tomogotchi-cli
+```
+
+## Controls
+
+- `q` or `Ctrl+C` - Quit the application
+
+## Architecture
+
+- `src/main.rs` - Entry point, terminal setup/teardown, main loop
+- `src/app.rs` - Application state management
+- `src/event.rs` - Input and tick event handling
+- `src/ui.rs` - TUI rendering with Ratatui
+
+## License
+
+MIT

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,23 @@
+/// Application state
+pub struct App {
+    /// Whether the application is running
+    pub running: bool,
+}
+
+impl App {
+    /// Create a new App instance
+    pub fn new() -> Self {
+        Self { running: true }
+    }
+
+    /// Quit the application
+    pub fn quit(&mut self) {
+        self.running = false;
+    }
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,32 @@
+use crossterm::event::{self, Event as CrosstermEvent, KeyEvent};
+use std::time::Duration;
+
+/// Events that can occur in the application
+pub enum Event {
+    /// A keyboard key was pressed
+    Key(KeyEvent),
+    /// A tick occurred (for periodic updates)
+    Tick,
+}
+
+/// Event handler that manages input and tick events
+pub struct EventHandler {
+    tick_rate: Duration,
+}
+
+impl EventHandler {
+    /// Create a new event handler with the given tick rate
+    pub fn new(tick_rate: Duration) -> Self {
+        Self { tick_rate }
+    }
+
+    /// Get the next event (blocking with timeout)
+    pub fn next(&self) -> std::io::Result<Event> {
+        if event::poll(self.tick_rate)? {
+            if let CrosstermEvent::Key(key) = event::read()? {
+                return Ok(Event::Key(key));
+            }
+        }
+        Ok(Event::Tick)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,62 @@
+mod app;
+mod event;
+mod ui;
+
+use app::App;
+use crossterm::{
+    event::KeyCode,
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use event::{Event, EventHandler};
+use ratatui::{backend::CrosstermBackend, Terminal};
+use std::{io, time::Duration};
+
+fn main() -> io::Result<()> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Create app state and event handler
+    let mut app = App::new();
+    let event_handler = EventHandler::new(Duration::from_millis(250));
+
+    // Main loop
+    let result = run_app(&mut terminal, &mut app, &event_handler);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_app<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    app: &mut App,
+    event_handler: &EventHandler,
+) -> io::Result<()> {
+    while app.running {
+        // Render UI
+        terminal.draw(|frame| ui::render(frame, app))?;
+
+        // Handle events
+        match event_handler.next()? {
+            Event::Key(key) => match key.code {
+                KeyCode::Char('q') | KeyCode::Char('Q') => app.quit(),
+                KeyCode::Char('c') if key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) => {
+                    app.quit()
+                }
+                _ => {}
+            },
+            Event::Tick => {
+                // Tick event - will be used for pet updates in future tickets
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,46 @@
+use crate::app::App;
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// Render the application UI
+pub fn render(frame: &mut Frame, _app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+    // Header
+    let header = Paragraph::new("Tomogotchi CLI")
+        .style(Style::default().fg(Color::Cyan))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(header, chunks[0]);
+
+    // Main area (placeholder for now)
+    let main = Paragraph::new("Your pet will appear here!")
+        .style(Style::default().fg(Color::White))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(main, chunks[1]);
+
+    // Footer with controls
+    let footer = Paragraph::new(Line::from(vec![
+        Span::raw("Press "),
+        Span::styled("q", Style::default().fg(Color::Yellow)),
+        Span::raw(" or "),
+        Span::styled("Ctrl+C", Style::default().fg(Color::Yellow)),
+        Span::raw(" to quit"),
+    ]))
+    .alignment(Alignment::Center)
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(footer, chunks[2]);
+}


### PR DESCRIPTION
[Engineer] Implements #2

## Summary
Set up the initial Rust project with Cargo, Ratatui and crossterm dependencies, and created the basic application skeleton with a main loop, event handling, and TUI rendering scaffold.

## What's included
- ✅ Cargo project initialized with proper metadata
- ✅ Dependencies: ratatui (0.29), crossterm (0.28), serde/serde_json
- ✅ Modular structure: `app.rs`, `ui.rs`, `event.rs`
- ✅ Terminal setup/teardown with raw mode and alternate screen
- ✅ Main event loop with 250ms tick rate
- ✅ Keyboard input handling via crossterm
- ✅ Graceful quit on `q` or `Ctrl+C`
- ✅ .gitignore for Rust projects
- ✅ README.md with project description and usage

## Verification
- `cargo build` succeeds with no warnings ✓
- `cargo run` launches a TUI with empty placeholder frame ✓
- Pressing `q` or `Ctrl+C` exits cleanly (terminal restored) ✓
- Code organized into clean module structure ✓

Ready for QA review!