### PR TITLE
[Engineer] Pet naming prompt on first launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Rust build artifacts
+/target/
+Cargo.lock
+
+# IDEs
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tomogotchi-cli"
+version = "0.1.0"
+edition = "2021"
+authors = ["Sedona Agent Fleet <agents@kabletv.com>"]
+description = "A CLI-based tamagotchi app built with Rust and Ratatui"
+
+[dependencies]
+ratatui = "0.29"
+crossterm = "0.28"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Tomogotchi CLI
+
+A CLI-based tamagotchi app built with Rust and Ratatui TUI framework.
+
+## Features (WIP)
+
+- 🎮 Interactive terminal UI
+- 🐾 Virtual pet with mood and stats
+- 🍖 Feed your pet
+- 🎾 Play with your pet
+- 💝 Keep your pet happy and healthy!
+
+## Prerequisites
+
+- Rust 1.70 or later
+- A terminal that supports Unicode and colors
+
+## Installation
+
+```bash
+cargo build --release
+```
+
+## Running
+
+```bash
+cargo run
+```
+
+Or after building:
+
+```bash
+./target/release/tomogotchi-cli
+```
+
+## Controls
+
+- `q` or `Ctrl+C` - Quit the application
+
+## Architecture
+
+- `src/main.rs` - Entry point, terminal setup/teardown, main loop
+- `src/app.rs` - Application state management
+- `src/event.rs` - Input and tick event handling
+- `src/ui.rs` - TUI rendering with Ratatui
+
+## License
+
+MIT

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,12 +1,25 @@
 use crate::pet::Pet;
 use std::time::Instant;
 
+/// Application lifecycle state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppState {
+    /// Player is naming their pet
+    Naming,
+    /// Normal running state with pet
+    Running,
+}
+
 /// Application state
 pub struct App {
     /// Whether the application is running
     pub running: bool,
-    /// The pet
-    pub pet: Pet,
+    /// Current app state (Naming or Running)
+    pub state: AppState,
+    /// The pet (created after naming)
+    pub pet: Option<Pet>,
+    /// Name input buffer (used during naming)
+    pub name_input: String,
     /// Last action feedback message with timestamp
     pub last_action: Option<(String, Instant)>,
 }
@@ -16,8 +29,37 @@ impl App {
     pub fn new() -> Self {
         Self {
             running: true,
-            pet: Pet::new("Tomo".to_string()),
+            state: AppState::Naming,
+            pet: None,
+            name_input: String::new(),
             last_action: None,
+        }
+    }
+
+    /// Add a character to the name input
+    pub fn input_char(&mut self, c: char) {
+        if self.state == AppState::Naming && self.name_input.len() < 20 {
+            self.name_input.push(c);
+        }
+    }
+
+    /// Remove last character from name input
+    pub fn input_backspace(&mut self) {
+        if self.state == AppState::Naming {
+            self.name_input.pop();
+        }
+    }
+
+    /// Confirm the pet name and transition to running state
+    pub fn confirm_name(&mut self) {
+        if self.state == AppState::Naming {
+            let name = if self.name_input.is_empty() {
+                "Tomo".to_string()
+            } else {
+                self.name_input.clone()
+            };
+            self.pet = Some(Pet::new(name));
+            self.state = AppState::Running;
         }
     }
 
@@ -28,7 +70,9 @@ impl App {
 
     /// Tick: update pet state
     pub fn tick(&mut self) {
-        self.pet.tick();
+        if let Some(pet) = &mut self.pet {
+            pet.tick();
+        }
         // Clear action messages after 2 seconds
         if let Some((_, timestamp)) = self.last_action {
             if timestamp.elapsed().as_secs() >= 2 {
@@ -39,14 +83,18 @@ impl App {
 
     /// Feed the pet
     pub fn feed(&mut self) {
-        self.pet.feed();
-        self.last_action = Some((format!("You fed {}!", self.pet.name), Instant::now()));
+        if let Some(pet) = &mut self.pet {
+            pet.feed();
+            self.last_action = Some((format!("You fed {}!", pet.name), Instant::now()));
+        }
     }
 
     /// Play with the pet
     pub fn play(&mut self) {
-        self.pet.play();
-        self.last_action = Some((format!("You played with {}!", self.pet.name), Instant::now()));
+        if let Some(pet) = &mut self.pet {
+            pet.play();
+            self.last_action = Some((format!("You played with {}!", pet.name), Instant::now()));
+        }
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use crate::pet::Pet;
+use std::time::Instant;
 
 /// Application state
 pub struct App {
@@ -6,6 +7,8 @@ pub struct App {
     pub running: bool,
     /// The pet
     pub pet: Pet,
+    /// Last action feedback message with timestamp
+    pub last_action: Option<(String, Instant)>,
 }
 
 impl App {
@@ -14,6 +17,7 @@ impl App {
         Self {
             running: true,
             pet: Pet::new("Tomo".to_string()),
+            last_action: None,
         }
     }
 
@@ -25,6 +29,24 @@ impl App {
     /// Tick: update pet state
     pub fn tick(&mut self) {
         self.pet.tick();
+        // Clear action messages after 2 seconds
+        if let Some((_, timestamp)) = self.last_action {
+            if timestamp.elapsed().as_secs() >= 2 {
+                self.last_action = None;
+            }
+        }
+    }
+
+    /// Feed the pet
+    pub fn feed(&mut self) {
+        self.pet.feed();
+        self.last_action = Some((format!("You fed {}!", self.pet.name), Instant::now()));
+    }
+
+    /// Play with the pet
+    pub fn play(&mut self) {
+        self.pet.play();
+        self.last_action = Some((format!("You played with {}!", self.pet.name), Instant::now()));
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,23 @@
+/// Application state
+pub struct App {
+    /// Whether the application is running
+    pub running: bool,
+}
+
+impl App {
+    /// Create a new App instance
+    pub fn new() -> Self {
+        Self { running: true }
+    }
+
+    /// Quit the application
+    pub fn quit(&mut self) {
+        self.running = false;
+    }
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,18 +1,30 @@
+use crate::pet::Pet;
+
 /// Application state
 pub struct App {
     /// Whether the application is running
     pub running: bool,
+    /// The pet
+    pub pet: Pet,
 }
 
 impl App {
     /// Create a new App instance
     pub fn new() -> Self {
-        Self { running: true }
+        Self {
+            running: true,
+            pet: Pet::new("Tomo".to_string()),
+        }
     }
 
     /// Quit the application
     pub fn quit(&mut self) {
         self.running = false;
+    }
+
+    /// Tick: update pet state
+    pub fn tick(&mut self) {
+        self.pet.tick();
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,32 @@
+use crossterm::event::{self, Event as CrosstermEvent, KeyEvent};
+use std::time::Duration;
+
+/// Events that can occur in the application
+pub enum Event {
+    /// A keyboard key was pressed
+    Key(KeyEvent),
+    /// A tick occurred (for periodic updates)
+    Tick,
+}
+
+/// Event handler that manages input and tick events
+pub struct EventHandler {
+    tick_rate: Duration,
+}
+
+impl EventHandler {
+    /// Create a new event handler with the given tick rate
+    pub fn new(tick_rate: Duration) -> Self {
+        Self { tick_rate }
+    }
+
+    /// Get the next event (blocking with timeout)
+    pub fn next(&self) -> std::io::Result<Event> {
+        if event::poll(self.tick_rate)? {
+            if let CrosstermEvent::Key(key) = event::read()? {
+                return Ok(Event::Key(key));
+            }
+        }
+        Ok(Event::Tick)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ fn run_app<B: ratatui::backend::Backend>(
                 KeyCode::Char('c') if key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) => {
                     app.quit()
                 }
+                KeyCode::Char('f') | KeyCode::Char('F') => app.feed(),
+                KeyCode::Char('p') | KeyCode::Char('P') => app.play(),
                 _ => {}
             },
             Event::Tick => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,15 +47,27 @@ fn run_app<B: ratatui::backend::Backend>(
 
         // Handle events
         match event_handler.next()? {
-            Event::Key(key) => match key.code {
-                KeyCode::Char('q') | KeyCode::Char('Q') => app.quit(),
-                KeyCode::Char('c') if key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) => {
-                    app.quit()
+            Event::Key(key) => {
+                use app::AppState;
+                match app.state {
+                    AppState::Naming => match key.code {
+                        KeyCode::Char(c) => app.input_char(c),
+                        KeyCode::Backspace => app.input_backspace(),
+                        KeyCode::Enter => app.confirm_name(),
+                        KeyCode::Esc => app.quit(),
+                        _ => {}
+                    },
+                    AppState::Running => match key.code {
+                        KeyCode::Char('q') | KeyCode::Char('Q') => app.quit(),
+                        KeyCode::Char('c') if key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) => {
+                            app.quit()
+                        }
+                        KeyCode::Char('f') | KeyCode::Char('F') => app.feed(),
+                        KeyCode::Char('p') | KeyCode::Char('P') => app.play(),
+                        _ => {}
+                    },
                 }
-                KeyCode::Char('f') | KeyCode::Char('F') => app.feed(),
-                KeyCode::Char('p') | KeyCode::Char('P') => app.play(),
-                _ => {}
-            },
+            }
             Event::Tick => {
                 app.tick();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,62 @@
+mod app;
+mod event;
+mod ui;
+
+use app::App;
+use crossterm::{
+    event::KeyCode,
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use event::{Event, EventHandler};
+use ratatui::{backend::CrosstermBackend, Terminal};
+use std::{io, time::Duration};
+
+fn main() -> io::Result<()> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Create app state and event handler
+    let mut app = App::new();
+    let event_handler = EventHandler::new(Duration::from_millis(250));
+
+    // Main loop
+    let result = run_app(&mut terminal, &mut app, &event_handler);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_app<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    app: &mut App,
+    event_handler: &EventHandler,
+) -> io::Result<()> {
+    while app.running {
+        // Render UI
+        terminal.draw(|frame| ui::render(frame, app))?;
+
+        // Handle events
+        match event_handler.next()? {
+            Event::Key(key) => match key.code {
+                KeyCode::Char('q') | KeyCode::Char('Q') => app.quit(),
+                KeyCode::Char('c') if key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) => {
+                    app.quit()
+                }
+                _ => {}
+            },
+            Event::Tick => {
+                // Tick event - will be used for pet updates in future tickets
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod event;
+mod pet;
 mod ui;
 
 use app::App;
@@ -54,7 +55,7 @@ fn run_app<B: ratatui::backend::Backend>(
                 _ => {}
             },
             Event::Tick => {
-                // Tick event - will be used for pet updates in future tickets
+                app.tick();
             }
         }
     }

--- a/src/pet.rs
+++ b/src/pet.rs
@@ -2,6 +2,10 @@
 const HUNGER_DECAY: u8 = 2;
 /// Happiness decay per tick
 const HAPPINESS_DECAY: u8 = 1;
+/// Hunger restored when fed
+const FEED_AMOUNT: u8 = 20;
+/// Happiness restored when played with
+const PLAY_AMOUNT: u8 = 15;
 
 /// Pet mood based on stats
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,6 +48,16 @@ impl Pet {
             20..=39 => Mood::Sad,
             _ => Mood::Miserable,
         }
+    }
+
+    /// Feed the pet, restoring hunger
+    pub fn feed(&mut self) {
+        self.hunger = self.hunger.saturating_add(FEED_AMOUNT).min(100);
+    }
+
+    /// Play with the pet, restoring happiness
+    pub fn play(&mut self) {
+        self.happiness = self.happiness.saturating_add(PLAY_AMOUNT).min(100);
     }
 }
 
@@ -96,5 +110,37 @@ mod tests {
         pet.hunger = 10;
         pet.happiness = 10;
         assert_eq!(pet.mood(), Mood::Miserable);
+    }
+
+    #[test]
+    fn test_feed_increases_hunger() {
+        let mut pet = Pet::new("Tomo".to_string());
+        pet.hunger = 50;
+        pet.feed();
+        assert_eq!(pet.hunger, 70);
+    }
+
+    #[test]
+    fn test_feed_caps_at_100() {
+        let mut pet = Pet::new("Tomo".to_string());
+        pet.hunger = 95;
+        pet.feed();
+        assert_eq!(pet.hunger, 100);
+    }
+
+    #[test]
+    fn test_play_increases_happiness() {
+        let mut pet = Pet::new("Tomo".to_string());
+        pet.happiness = 50;
+        pet.play();
+        assert_eq!(pet.happiness, 65);
+    }
+
+    #[test]
+    fn test_play_caps_at_100() {
+        let mut pet = Pet::new("Tomo".to_string());
+        pet.happiness = 90;
+        pet.play();
+        assert_eq!(pet.happiness, 100);
     }
 }

--- a/src/pet.rs
+++ b/src/pet.rs
@@ -1,0 +1,100 @@
+/// Hunger decay per tick
+const HUNGER_DECAY: u8 = 2;
+/// Happiness decay per tick
+const HAPPINESS_DECAY: u8 = 1;
+
+/// Pet mood based on stats
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mood {
+    Happy,
+    Content,
+    Sad,
+    Miserable,
+}
+
+/// The pet with stats and state
+pub struct Pet {
+    pub name: String,
+    pub hunger: u8,
+    pub happiness: u8,
+}
+
+impl Pet {
+    /// Create a new pet with starting stats
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            hunger: 80,
+            happiness: 80,
+        }
+    }
+
+    /// Tick: decay stats over time
+    pub fn tick(&mut self) {
+        self.hunger = self.hunger.saturating_sub(HUNGER_DECAY);
+        self.happiness = self.happiness.saturating_sub(HAPPINESS_DECAY);
+    }
+
+    /// Calculate current mood from stats
+    pub fn mood(&self) -> Mood {
+        let avg = (self.hunger as u16 + self.happiness as u16) / 2;
+        match avg {
+            70..=100 => Mood::Happy,
+            40..=69 => Mood::Content,
+            20..=39 => Mood::Sad,
+            _ => Mood::Miserable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_pet_starts_healthy() {
+        let pet = Pet::new("Tomo".to_string());
+        assert_eq!(pet.hunger, 80);
+        assert_eq!(pet.happiness, 80);
+        assert_eq!(pet.mood(), Mood::Happy);
+    }
+
+    #[test]
+    fn test_tick_decays_stats() {
+        let mut pet = Pet::new("Tomo".to_string());
+        pet.tick();
+        assert_eq!(pet.hunger, 78);
+        assert_eq!(pet.happiness, 79);
+    }
+
+    #[test]
+    fn test_tick_clamps_at_zero() {
+        let mut pet = Pet::new("Tomo".to_string());
+        pet.hunger = 1;
+        pet.happiness = 0;
+        pet.tick();
+        assert_eq!(pet.hunger, 0);
+        assert_eq!(pet.happiness, 0);
+    }
+
+    #[test]
+    fn test_mood_thresholds() {
+        let mut pet = Pet::new("Tomo".to_string());
+        
+        pet.hunger = 80;
+        pet.happiness = 80;
+        assert_eq!(pet.mood(), Mood::Happy);
+        
+        pet.hunger = 50;
+        pet.happiness = 50;
+        assert_eq!(pet.mood(), Mood::Content);
+        
+        pet.hunger = 30;
+        pet.happiness = 30;
+        assert_eq!(pet.mood(), Mood::Sad);
+        
+        pet.hunger = 10;
+        pet.happiness = 10;
+        assert_eq!(pet.mood(), Mood::Miserable);
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,46 @@
+use crate::app::App;
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// Render the application UI
+pub fn render(frame: &mut Frame, _app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+    // Header
+    let header = Paragraph::new("Tomogotchi CLI")
+        .style(Style::default().fg(Color::Cyan))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(header, chunks[0]);
+
+    // Main area (placeholder for now)
+    let main = Paragraph::new("Your pet will appear here!")
+        .style(Style::default().fg(Color::White))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(main, chunks[1]);
+
+    // Footer with controls
+    let footer = Paragraph::new(Line::from(vec![
+        Span::raw("Press "),
+        Span::styled("q", Style::default().fg(Color::Yellow)),
+        Span::raw(" or "),
+        Span::styled("Ctrl+C", Style::default().fg(Color::Yellow)),
+        Span::raw(" to quit"),
+    ]))
+    .alignment(Alignment::Center)
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(footer, chunks[2]);
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,12 +8,13 @@ use ratatui::{
 };
 
 /// Render the application UI
-pub fn render(frame: &mut Frame, _app: &App) {
+pub fn render(frame: &mut Frame, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
             Constraint::Min(0),
+            Constraint::Length(3),
             Constraint::Length(3),
         ])
         .split(frame.area());
@@ -32,15 +33,28 @@ pub fn render(frame: &mut Frame, _app: &App) {
         .block(Block::default().borders(Borders::ALL));
     frame.render_widget(main, chunks[1]);
 
+    // Action feedback area
+    let feedback_text = if let Some((message, _)) = &app.last_action {
+        message.clone()
+    } else {
+        String::new()
+    };
+    let feedback = Paragraph::new(feedback_text)
+        .style(Style::default().fg(Color::Green))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(feedback, chunks[2]);
+
     // Footer with controls
     let footer = Paragraph::new(Line::from(vec![
-        Span::raw("Press "),
+        Span::styled("f", Style::default().fg(Color::Yellow)),
+        Span::raw(": Feed | "),
+        Span::styled("p", Style::default().fg(Color::Yellow)),
+        Span::raw(": Play | "),
         Span::styled("q", Style::default().fg(Color::Yellow)),
-        Span::raw(" or "),
-        Span::styled("Ctrl+C", Style::default().fg(Color::Yellow)),
-        Span::raw(" to quit"),
+        Span::raw(": Quit"),
     ]))
     .alignment(Alignment::Center)
     .block(Block::default().borders(Borders::ALL));
-    frame.render_widget(footer, chunks[2]);
+    frame.render_widget(footer, chunks[3]);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,37 +1,151 @@
-use crate::app::App;
+use crate::app::{App, AppState};
+use crate::pet::Mood;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Gauge, Paragraph},
     Frame,
 };
 
+/// ASCII art for each mood state
+const HAPPY_PET: &str = r#"
+   /\_/\  
+  ( ^.^ ) 
+   > ^ <
+"#;
+
+const CONTENT_PET: &str = r#"
+   /\_/\  
+  ( -.- ) 
+   > - <
+"#;
+
+const SAD_PET: &str = r#"
+   /\_/\  
+  ( ;_; ) 
+   > ~ <
+"#;
+
+const MISERABLE_PET: &str = r#"
+   /\_/\  
+  ( x_x ) 
+   > _ <
+"#;
+
 /// Render the application UI
 pub fn render(frame: &mut Frame, app: &App) {
+    match app.state {
+        AppState::Naming => render_naming_screen(frame, app),
+        AppState::Running => render_running_screen(frame, app),
+    }
+}
+
+/// Render the naming screen
+fn render_naming_screen(frame: &mut Frame, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
+            Constraint::Percentage(40),
             Constraint::Length(3),
-            Constraint::Min(0),
-            Constraint::Length(3),
+            Constraint::Percentage(40),
             Constraint::Length(3),
         ])
         .split(frame.area());
 
-    // Header
-    let header = Paragraph::new("Tomogotchi CLI")
+    // Title
+    let title = Paragraph::new("Welcome to Tomogotchi!")
         .style(Style::default().fg(Color::Cyan))
+        .alignment(Alignment::Center);
+    frame.render_widget(title, chunks[0]);
+
+    // Input field
+    let input_text = if app.name_input.is_empty() {
+        "Tomo".to_string() // Show default name
+    } else {
+        app.name_input.clone()
+    };
+    
+    let input = Paragraph::new(input_text)
+        .style(Style::default().fg(Color::Yellow))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL).title("Name your pet:"));
+    frame.render_widget(input, chunks[1]);
+
+    // Instructions
+    let instructions = Paragraph::new("Type a name and press Enter\n(Leave empty for 'Tomo' | Esc to quit)")
+        .style(Style::default().fg(Color::Gray))
+        .alignment(Alignment::Center);
+    frame.render_widget(instructions, chunks[3]);
+}
+
+/// Render the main running screen
+fn render_running_screen(frame: &mut Frame, app: &App) {
+    let Some(pet) = &app.pet else {
+        return; // Should never happen, but safety first
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),  // Header (name + mood)
+            Constraint::Min(5),     // Main area (pet ASCII)
+            Constraint::Length(3),  // Hunger gauge
+            Constraint::Length(3),  // Happiness gauge
+            Constraint::Length(3),  // Action feedback
+            Constraint::Length(3),  // Footer (controls)
+        ])
+        .split(frame.area());
+
+    // Header: pet name and mood
+    let mood = pet.mood();
+    let (mood_label, mood_color) = match mood {
+        Mood::Happy => ("Happy 😊", Color::Green),
+        Mood::Content => ("Content 😌", Color::Yellow),
+        Mood::Sad => ("Sad 😞", Color::LightRed),
+        Mood::Miserable => ("Miserable 😭", Color::Red),
+    };
+    
+    let header_text = format!("{} is {}", pet.name, mood_label);
+    let header = Paragraph::new(header_text)
+        .style(Style::default().fg(mood_color))
         .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL));
     frame.render_widget(header, chunks[0]);
 
-    // Main area (placeholder for now)
-    let main = Paragraph::new("Your pet will appear here!")
-        .style(Style::default().fg(Color::White))
+    // Main area: ASCII art pet
+    let pet_art = match mood {
+        Mood::Happy => HAPPY_PET,
+        Mood::Content => CONTENT_PET,
+        Mood::Sad => SAD_PET,
+        Mood::Miserable => MISERABLE_PET,
+    };
+    
+    let pet_widget = Paragraph::new(pet_art)
+        .style(Style::default().fg(mood_color))
         .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL));
-    frame.render_widget(main, chunks[1]);
+    frame.render_widget(pet_widget, chunks[1]);
+
+    // Hunger gauge
+    let hunger_ratio = pet.hunger as f64 / 100.0;
+    let hunger_color = stat_color(pet.hunger);
+    let hunger_gauge = Gauge::default()
+        .block(Block::default().borders(Borders::ALL).title("Hunger"))
+        .gauge_style(Style::default().fg(hunger_color))
+        .ratio(hunger_ratio)
+        .label(format!("{}/100", pet.hunger));
+    frame.render_widget(hunger_gauge, chunks[2]);
+
+    // Happiness gauge
+    let happiness_ratio = pet.happiness as f64 / 100.0;
+    let happiness_color = stat_color(pet.happiness);
+    let happiness_gauge = Gauge::default()
+        .block(Block::default().borders(Borders::ALL).title("Happiness"))
+        .gauge_style(Style::default().fg(happiness_color))
+        .ratio(happiness_ratio)
+        .label(format!("{}/100", pet.happiness));
+    frame.render_widget(happiness_gauge, chunks[3]);
 
     // Action feedback area
     let feedback_text = if let Some((message, _)) = &app.last_action {
@@ -43,7 +157,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         .style(Style::default().fg(Color::Green))
         .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL));
-    frame.render_widget(feedback, chunks[2]);
+    frame.render_widget(feedback, chunks[4]);
 
     // Footer with controls
     let footer = Paragraph::new(Line::from(vec![
@@ -56,5 +170,14 @@ pub fn render(frame: &mut Frame, app: &App) {
     ]))
     .alignment(Alignment::Center)
     .block(Block::default().borders(Borders::ALL));
-    frame.render_widget(footer, chunks[3]);
+    frame.render_widget(footer, chunks[5]);
+}
+
+/// Get color based on stat value
+fn stat_color(value: u8) -> Color {
+    match value {
+        70..=100 => Color::Green,
+        40..=69 => Color::Yellow,
+        _ => Color::Red,
+    }
 }


### PR DESCRIPTION
[Engineer] Implements ticket #6

## Description
Added a pet naming screen on first launch to personalize the experience.

## Changes
- **AppState enum**: Added `Naming` and `Running` states to manage app lifecycle
- **Naming screen**: 
  - Clean UI with "Name your pet:" prompt
  - Text input field with character limit (20 chars)
  - Shows default name "Tomo" placeholder
  - Instructions: "Type a name and press Enter (Leave empty for 'Tomo' | Esc to quit)"
- **Input handling**:
  - Character input adds to name buffer
  - Backspace removes last character
  - Enter confirms and transitions to Running state
  - Esc quits during naming
- **Pet creation**: Pet is created with the entered name (or "Tomo" if empty)
- **State management**: App starts in Naming state, transitions to Running after confirmation

## Technical Details
- Modified `App` struct to include `state: AppState`, `pet: Option<Pet>`, and `name_input: String`
- Updated event handler in `main.rs` to route key events based on current state
- Split UI rendering into `render_naming_screen` and `render_running_screen`
- All actions (feed/play/tick) safely handle `Option<Pet>` with proper guards

## Acceptance Criteria
- ✅ App starts with naming screen before showing pet
- ✅ Player can type a name
- ✅ Backspace works for editing
- ✅ Empty input defaults to "Tomo"
- ✅ Pet's name appears in main TUI after naming
- ✅ Enter confirms and transitions to pet view
- ✅ Clean UI with helpful instructions

## Testing
```bash
cargo build
cargo run
# Try: type a name, backspace, submit empty, submit custom name
```

Closes #6